### PR TITLE
fix miselecting architechture

### DIFF
--- a/setup-termux-alpine
+++ b/setup-termux-alpine
@@ -33,9 +33,10 @@ trap "TRAP_SIGNAL $? $LINENO" HUP INT TERM
 ## Checking the architecture for URL paths
 function check_architecture() {
     task "Checking the architecture"
-    case `dpkg --print-architecture` in
+    case `uname -m` in
         aarch64) ARCH=aarch64 ;;
-        arm) ARCH=armhf ;;
+        armhf) ARCH=armhf ;;
+	armv7l) ARCH=armv7 ;;
         amd64) ARCH=x86_64 ;;
         x86_64) ARCH=x86_64 ;;
         i*86) ARCH=x86 ;;


### PR DESCRIPTION
Fix ISSUE #1. `uname -m` returns a more precise architecture, so I fix the issue using it